### PR TITLE
docs: add missed step in clone the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Microscope is a blockchain explorer built with [React](https://reactjs.org/) for
 1.  clone the repo
 
 ```shell
-git clone https://github.com/cryptape/microscope/
+git clone https://github.com/cryptape/microscope/ && cd microscope
 ```
 
 2.  Install Dependencies


### PR DESCRIPTION
add `&& cd microscope` to change the directory to `microscope`